### PR TITLE
Removed unused done callback of close event listener

### DIFF
--- a/modbus-serial.js
+++ b/modbus-serial.js
@@ -296,7 +296,7 @@ module.exports = function(RED) {
       }
     }
 
-    node.on('close', function(done){
+    node.on('close', function(){
       clearInterval(node.interval);
     });
   }


### PR DESCRIPTION
If the listener of a close event accepts a done callback it must be called. Else Node-red will hang, waiting for the callback to be called, while stopping flows where this node is included. In this particular case, without any asynchronous calls in the close listener, there is no need to use the done callback.