### PR TITLE
Error code was not printed

### DIFF
--- a/modbus-serial.js
+++ b/modbus-serial.js
@@ -102,7 +102,7 @@ module.exports = function(RED) {
         if (promise) {
           promise
           .catch(function (err){
-            node.log("Error: ", err);
+            node.log("Error: " + err);
           })
           .then(function (data){
             if (obj.callback) {


### PR DESCRIPTION
Errors caught  from the modbus master was not printed properly. The log method of a node does only accept one message argument.