### PR TITLE
Node stops working if request with callback fails

### DIFF
--- a/modbus-serial.js
+++ b/modbus-serial.js
@@ -105,10 +105,12 @@ module.exports = function(RED) {
             node.log("Error: " + err);
           })
           .then(function (data){
-            if (obj.callback) {
-              obj.callback(data);
-            } else {
-              node.log("no callback");
+            if (typeof data !== 'undefined') {
+              if (obj.callback) {
+                obj.callback(data);
+              } else {
+                node.log("no callback");
+              }
             }
           }).then(function (){
             processList();


### PR DESCRIPTION
If a Modbus request fails (e.g. timed out) and it has a callback to be processed upon receiving a response the node will stop working because the data variable is undefined in this case.